### PR TITLE
[BAD] Made a tiny change and whitespace

### DIFF
--- a/TheBadDemo/UWCDemo/DadJokesService.cs
+++ b/TheBadDemo/UWCDemo/DadJokesService.cs
@@ -52,20 +52,20 @@ namespace UWCDemo
             return cloudJokes;
         }
 
-		public async Task<IEnumerable<Joke>> GetCloudJokesAsync(int page, int limit)
-		{
+        public async Task<IEnumerable<Joke>> GetCloudJokesAsync(int page, int limit)
+        {
             // try the cloud
-			var cloudJokes = await client.SearchJokesAsync(page: page + 1, limit: limit);
+            var results = await client.SearchJokesAsync(page: page + 1, limit: limit);
 
-			// convert the cloud jokes into our jokes
-			var jokes = cloudJokes.Results.Select(r => new Joke
-			{
+            // convert the cloud jokes into our jokes
+            var jokes = results.Results.Select(r => new Joke
+            {
                 Id = r.Id,
                 JokeText = r.Joke
-			}).ToArray();
+            }).ToArray();
 
-			return jokes;
-		}
+            return jokes;
+        }
 
         public async Task<IEnumerable<Joke>> GetLocalJokesAsync(int page, int limit)
         {


### PR DESCRIPTION
This is a classic example of making a change - often small - along with a massive chunk of whitespaces. 
The whitespace hides everything.

Although we do have to fix the whitespace at some point, rather do it when there is a bigger change and the ratio of whitespace to change is better. Or, do it as a separate, whitespace-only PR. Or, just live with it as you WILL lose history.

You can see the actual changes in this diff: https://github.com/mattleibow/UWCDemo/compare/example/change-in-whitespace?w=1